### PR TITLE
Fix OpenSSL strings sometimes generating with escape characters and breaking DB authentication

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -100,8 +100,8 @@ configure_env() {
     cp "$PROJECT_ROOT/env.example" "$env_file"
 
     # Generate secrets
-    SECRET_KEY=$(openssl rand -hex 32)
-    DB_PASS=$(openssl rand -base64 32)
+    SECRET_KEY="$(openssl rand -hex 32)"
+    DB_PASS="$(openssl rand -base64 32)"
 
     # Update .env file
     sed_inplace "s|^APP_PORT=.*|APP_PORT=$port|" "$env_file"


### PR DESCRIPTION
## Description

When testing this project, I noticed that sometimes the install.sh script would run, but then the app container restarts indefinitely. Tailing the docker logs on the app container showed me that the cause was a failing password authentication with the DB user.

I found that this issue only occurrs SOMETIMES, when the openssl commands generate a string with a character such as "=" or similar. Seems to cause the parsing of the script to incorrectly load a password that is different from what's in the .env file.
Simply wrapping the openssl commands in quotes fixes this issue.

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test A
The manual fix for this is to enter the DB container, and manually change the ideon users password to what is in the .env file. 
- [x] Test B
Fully removing all configuration and setting up from scratch, with the changes made in the pull request, leads to consistency in deployment every time.

Super simple, should help with new setups :)