### PR TITLE
fix: wrap project page queries in withAuthenticatedSession for RLS

### DIFF
--- a/src/app/(main)/project/[id]/page.tsx
+++ b/src/app/(main)/project/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import { cookies } from "next/headers";
 import { loadDictionaries } from "@i18n/loader";
-import { getDb } from "@lib/db";
+import { getDb, withAuthenticatedSession } from "@lib/db";
 import { getProjectsQuery } from "@lib/queries";
 import ProjectClient from "./ProjectClient";
 import { getAuthUser } from "@auth";
@@ -20,17 +20,21 @@ export async function generateMetadata({
   const dict = dictionaries[lang] || dictionaries["en"];
 
   if (id && id !== "undefined") {
-    const db = getDb();
-    const project = await db
-      .selectFrom("projects")
-      .select("name")
-      .where("id", "=", id)
-      .executeTakeFirst();
+    const user = await getAuthUser();
+    if (user) {
+      const project = await withAuthenticatedSession(user.id, async (tx) => {
+        return tx
+          .selectFrom("projects")
+          .select("name")
+          .where("id", "=", id)
+          .executeTakeFirst();
+      });
 
-    if (project) {
-      return {
-        title: project.name,
-      };
+      if (project) {
+        return {
+          title: project.name,
+        };
+      }
     }
   }
 
@@ -53,20 +57,37 @@ export default async function ProjectPage({
 
   const db = getDb();
 
-  // Check access using centralized query logic
-  const projectWithAccess = await getProjectsQuery(db, user.id, null, null, [
-    id,
-  ]).executeTakeFirst();
+  // Check access using centralized query logic, inside an authenticated session
+  // so PostgreSQL RLS policies have the current user ID set correctly.
+  const projectWithAccess = await withAuthenticatedSession(
+    user.id,
+    async (tx) => {
+      return getProjectsQuery(tx, user.id, null, null, [id]).executeTakeFirst();
+    },
+  );
 
   if (!projectWithAccess) {
-    // Check if project exists at all
+    // Check if project exists at all. This query runs outside RLS scope intentionally:
+    // getProjectsQuery already enforces access control at the application level,
+    // so we only need an existence check here — not an access check.
+    // We use a raw pool query to bypass FORCE ROW LEVEL SECURITY on the projects table.
     let project;
     try {
-      project = await db
-        .selectFrom("projects")
-        .select("name")
-        .where("id", "=", id)
-        .executeTakeFirst();
+      const pool = (await import("@lib/db")).getPool();
+      if (pool) {
+        const result = await pool.query<{ name: string }>(
+          'SELECT name FROM projects WHERE id = $1',
+          [id],
+        );
+        project = result.rows[0] ?? null;
+      } else {
+        // SQLite fallback (no RLS)
+        project = await db
+          .selectFrom("projects")
+          .select("name")
+          .where("id", "=", id)
+          .executeTakeFirst();
+      }
     } catch (error) {
       console.error("Failed to fetch project details:", error);
       project = null;
@@ -76,15 +97,17 @@ export default async function ProjectPage({
       notFound();
     }
 
-    // Check for pending request
+    // Check for pending request, inside an authenticated session for RLS
     let request;
     try {
-      request = await db
-        .selectFrom("projectRequests")
-        .select("status")
-        .where("projectId", "=", id)
-        .where("userId", "=", user.id)
-        .executeTakeFirst();
+      request = await withAuthenticatedSession(user.id, async (tx) => {
+        return tx
+          .selectFrom("projectRequests")
+          .select("status")
+          .where("projectId", "=", id)
+          .where("userId", "=", user.id)
+          .executeTakeFirst();
+      });
     } catch (error) {
       console.error("Failed to fetch project request:", error);
       request = null;


### PR DESCRIPTION
## Problem

When navigating to `/project/:id`, the page returns a 404 even for projects that exist and were just created by the authenticated user.

**Root cause:** `ProjectPage` and `generateMetadata` call `getDb()` directly and execute queries outside any `withAuthenticatedSession()` scope. This means `set_config('app.current_user_id', userId, true)` is never called before the queries run. The RLS policies on the `projects` table evaluate `current_setting('app.current_user_id', true)` as `null`/empty, and since the table has `FORCE ROW LEVEL SECURITY`, every row is blocked — including the bare existence check fallback. This causes `notFound()` to be called unconditionally, resulting in a 404.

This is particularly apparent on PostgreSQL 17/18 where the handling of unset custom parameters is stricter.

## Fix

- Wrap the `getProjectsQuery` call in `withAuthenticatedSession()` so the user ID is set via `set_config` before RLS policy evaluation
- Wrap the `projectRequests` lookup in `withAuthenticatedSession()` for the same reason
- Fix `generateMetadata` to also use `withAuthenticatedSession` when a user session is available
- Use a raw `pool.query()` for the bare project existence check (the fallback shown when access is denied). This intentionally bypasses `FORCE ROW LEVEL SECURITY` — `getProjectsQuery` already enforces access control at the application level, so the fallback only needs to determine whether a project *exists*, not whether the current user *can access it*. On SQLite (dev), it falls back to the normal Kysely query since there is no RLS.

## Testing

1. Deploy with PostgreSQL (16 or newer)
2. Create a new project
3. Click the project — it should open correctly instead of showing 404